### PR TITLE
Add README.md in three subdirectories

### DIFF
--- a/dns/README.md
+++ b/dns/README.md
@@ -1,0 +1,79 @@
+# Alternator - DNS load balancing - proof-of-concept
+
+## Introduction
+As explained in the [toplevel README](../README.md), DynamoDB clients
+are usually aware of a **single endpoint**, a single URL to which they
+connect - e.g., `http://dynamodb.us-east-1.amazonaws.com`. One of the
+approaches with which requests to a single URL can be directed many
+Scylla nodes is via a DNS server: We can configure a DNS server to return
+one of the live Scylla nodes (in the relevant data center). If we assume
+that there are many different clients, the overall load will be balanced.
+
+Scylla provides a simple HTTP request, "`/localnodes`", with which we
+can retrieve the current list of live nodes in this data center.
+
+## dns-loadbalancer.py
+**Any** configurable DNS server can be used for this purpose. A script
+can periodically fetch the current list of live nodes by sending a
+`/localnodes` request to any previously-known live node. The script can
+then configure the DNS server to randomly return nodes from this list (or
+return random subsets from this list) for the chosen domain name.
+
+The Python program `dns-loadbalancer.py` is a self-contained example of
+this approach. It is not meant to be used for production workloads, but
+more as a *proof of concept*, of what can be done. The code uses the Python
+library **dnslib** to serve DNS requests on port 53 (both UDP and TCP).
+Requests to _any_ domain name are answered by one of the live Scylla nodes
+at random. The Python code also periodically (once every second) makes a
+`/localnodes` request to one of the known nodes to refresh the list of
+live nodes.
+
+To use `dns-loadbalancer.py`, run it on some machine, and set up an
+existing name server to point a specific domain name, e.g.,
+`alternator.example.com` to this name server (i.e., an `NS` record).
+Now, whenever the application tries to resolve `alternator.example.com`
+our machine running `dns-loadbalancer.py` gets the request, and can
+respond with a random Scylla node.
+
+If your setup does not have any DNS server or domain name which you can
+control (as `alternator.example.com` in the above example), an alternative
+setup is to configure the client machine to use the demo DNS as its
+default DNS server. This means that the demo DNS server will receive **all**
+DNS requests, so the code needs to be changed (a bit) to only return random
+Scylla nodes for a specific "fake" domain (e.g., `alternator.example.com`,
+even if you don't control that domain), and pass on every other requests to
+a real name server.
+
+`dns-loadbalancer.py` should be edited to change the Alternator port
+number (which must be identical across the cluster) - in the `alternator_port`
+variable - and also an initial list of known Scylla nodes in the `livenodes`
+variable. As explained above, this list will be refreshed every one second,
+but this process must start by at least one known nodes, which we can
+contact to find the list of all the nodes.
+
+## Example
+
+In the following example, Scylla is running on port 8000 on three
+IP addresses - 127.0.0.1, 127.0.0.2, and 127.0.0.3. The initial
+`livenodes` list contains just 127.0.0.1.
+
+```
+$ sudo ./dns-loadbalancer.py
+updating livenodes from http://127.0.0.1:8000/localnodes
+['127.0.0.2', '127.0.0.3', '127.0.0.1']
+...
+```
+
+```
+$ dig @localhost alternator.example.com
+...
+;; ANSWER SECTION:
+alternator.example.com.	4	IN	A	127.0.0.3
+$ dig @localhost alternator.example.com
+...
+;; ANSWER SECTION:
+alternator.example.com.	4	IN	A	127.0.0.2
+```
+
+Note how each response returns one of the three live nodes at random,
+with a TTL of 4 seconds.

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,68 @@
+# Alternator - Client-side load balancing - Go
+
+## Introduction
+As explained in the [toplevel README](../README.md), DynamoDB applications
+are usually aware of a _single endpoint_, a single URL to which they
+connect - e.g., `http://dynamodb.us-east-1.amazonaws.com`. But Alternator
+is distributed over a cluster of nodes and we would like the application to
+send requests to all these nodes - not just to one. This is important for two
+reasons: **high availability** (the failure of a single Alternator node should
+not prevent the client from proceeding) and **load balancing** over all
+Alternator nodes.
+
+One of the ways to do this is to provide a modified library, which will
+allow a mostly-unmodified application which is only aware of one
+"enpoint URL" to send its requests to many different Alternator nodes.
+
+Our intention is _not_ to fork the existing AWS client library for Go.
+Rather, our intention is to provide a small library which tacks on to
+the existing "aws-sdk-go" library which the application is already using,
+and makes it do the right thing for Alternator.
+
+## The `alternator_lb.go` library
+The `AlternatorNodes` class defined in `alternator_lb.go` can be used to
+easily change any application using `aws-sdk-go` from using Amazon DynamoDB
+to use Alternator: While DynamoDB only has one "endpoint", this class helps
+us balance the requests between all the nodes in the Alternator cluster.
+ 
+## Using the library
+To use this class, simply replace the code which creates a AWS SDK
+`session.Session`
+Instead of the usual way of creating a `Seassion`, like:
+```golang
+sess := session.Must(session.NewSessionWithOptions(session.Options{
+            SharedConfigState: session.SharedConfigEnable,
+```
+Use an `AlternatorNodes` object, which keeps track of the live Alternator
+nodes, to create a session with the following commands:
+```golang
+alternator_nodes := NewAlternatorNodes("http", 8000, []string {"127.0.0.1"})
+sess := alternator_nodes.session("dog.scylladb.com", "alternator", "secret_pass")
+```
+Then, the rest of the applicaton can use this session normally - call
+`db := dynamodb.New(sess)` and then send DynamoDB requests to db; As
+usual, this `db` object is thread-safe and can be used from multiple
+threads.
+
+The parameters to `NewAlternatorNodes()` indicate a list of known
+Alternator nodes, and their common scheme (http or https) and port.
+This list can contain one or more nodes - we then periodically contact
+ these nodes to fetch the full list of nodes using Alternator's
+`/localnodes` request. In the `session()` method, one needs to pick a
+"fake domain" which doesn't really mean anything (except it will be used as
+the Host header, and be returned by the DescribeEndpoints request), and
+the key and secret key for authentication to Alternator.
+
+Every request performed on this new session will pick a different live
+Alternator node to send it to. Despite us sending different requests
+ to different nodes, Go will keep these connections cached and reuse them
+when we send another request to the same node.
+
+(TODO: figure out the limitations of this caching. Where is it documented?).
+
+## Example
+
+This directory also contains two trivial examples of using `alternator_lb.go`,
+[try.go](try.go). This example opens a session using `NewAlternatorNodes()`, as
+described above, and then uses it 20 times in a loop - and we'll see
+that every request will be sent to a different node.

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,112 @@
+# Alternator - Client-side load balancing - Python
+
+## Introduction
+As explained in the [toplevel README](../README.md), DynamoDB applications
+are usually aware of a _single endpoint_, a single URL to which they
+connect - e.g., `http://dynamodb.us-east-1.amazonaws.com`. But Alternator
+is distributed over a cluster of nodes and we would like the application to
+send requests to all these nodes - not just to one. This is important for two
+reasons: **high availability** (the failure of a single Alternator node should
+not prevent the client from proceeding) and **load balancing** over all
+Alternator nodes.
+
+One of the ways to do this is to provide a modified library, which will
+allow a mostly-unmodified application which is only aware of one
+"enpoint URL" to send its requests to many different Alternator nodes.
+
+Our intention is _not_ to fork the existing AWS client library for Python -
+**boto3**. Rather, our intention is to provide a small library which tacks
+on to any version of boto3 that the application is already using, and makes
+boto3 do the right thing for Alternator.
+
+## The `boto3_alternator` library
+Use `import boto3_alternator` to make any unmodified boto3 client use
+multiple nodes of an Alternator cluster instead of just one (which you'll
+normally get if providing just one node's IP address as the endpoint URL).
+
+This library provides two alternative modes:
+1. Every time that boto3 needs to open a connection to DynamoDB,
+   it will pick a different live Alternator node. When a connection
+   breaks and a new connection needs to be opened, it will pick a
+   destination again.
+2. Every time that boto3 sends a *request* to DynamoDB, it will send it
+   to a different live Alternator node. Two consecutive requests will
+   often go to different nodes. Connections may be reused, however, if
+   a large number of requests are sent from the same thread (boto3
+   "resource") - botocore's "connection pool" feature is responsible for
+   this reuse, and is limited by botocore's connection pool size.
+
+The first mode is best when an application has many threads or boto3
+"resources" - as each of those opens a different connection. The second
+mode is better when the application only has one or very few threads or
+boto3 "resources". The second mode sends each request to a different
+Alternator node, instead of sending all these requests over an already
+established connection, so this mode is contraindicated when the client
+has many threads or boto3 "resources" because each of these resources,
+instead of keeping one open connection, will keep many (the size
+of botocore's "connection pool") to many different Alternator nodes.
+
+Both modes start an additional thread which periodically updates the
+list of live Alternator nodes by contacting one of the known nodes and
+asking it for a list of the rest (in this data-center).
+
+Both modes work by "monkey-patching", or instrumenting, different
+library functions:
+1. The first mode monkey-patches `socket.getaddrinfo`, so every time
+   boto3 uses it to open a new connection, it will pick a different node.
+2. The second mode monkey-patches botocore's request-sending function,
+   `botocore.httpsession.URLLib3Session.send`, so that each request
+   is sent to a different node.
+
+## Using the library
+To use this library, import it and then run the `setup1()` or `setup2()`
+function to pick between the two different modes described above:
+
+```python
+import boto3_alternator
+
+alternator_url = boto3_alternator_3.setup1(
+    # A list of known Alternator nodes. One of them must be responsive.
+    ['127.0.0.1'],
+    # Alternator scheme (http or https) and port
+   'http', 8000,
+    # A "fake" domain name which, if used by the application, will be
+    # resolved to one of the Scylla nodes.
+    'dog.scylla.com')
+
+# The setup function returns the "endpoint URL", in this example it will be
+# "http://dog.scylla.com:8000/". You will need to use this endpoint URL to
+# create the boto3 resource, e.g.,
+dynamodb = boto3.resource('dynamodb', endpoint_url=alternator_url,
+               aws_access_key_id='???', aws_secret_access_key='???')
+```
+
+The "fake domain", in this example, `dog.scylla.com`, can be any domain name,
+it doesn't need to exist - and in fact, it probably shouldn't. After
+`setup1()` or `setup2()` is run, attempts to use this domain name in boto3
+are captured and forwarded to one of the live Alternator nodes - so the
+real DNS is never asked about `dog.scylla.com`.
+
+## Examples
+
+This directory also contains two trivial examples of using `boto3_alternator`,
+(try1.py) and (try2.py):
+* `try1.py` demonstrates `setup1()`. It first demonstrates that we if we open
+   five different boto3 "resources" and send a request `describe_endpoints()`
+   to each one, they will arrive at different Alternator nodes.
+   Then, this example makes 100 consecutive requests, with a 2 second
+   delay between requests. Because all these requests use the same
+   boto3 "resource", the `setup1()` mode means that all requests are sent
+   to the same node. However, `boto3_alternator` still guarantees high
+   availability: if during this long loop one kills this chosen Alternator
+   node, `boto3_alternator` will automatically notice this, will create a
+   connection to some other Alternator node, and requests will continued to
+   succeed.
+* `try2.py` demonstrates `setup2()`. It creates just one boto3 "resource",
+   and then makes ten requests to it - which can be seen are each sent to
+   a different Alternator node.
+
+Both examples initialize the library assuming that one Alternator node is
+available at `http://127.0.0.1:8000`, from which `boto3_alternator` 
+will discover the rest. You can edit the examples to point them to
+Alternator running elsewhere.


### PR DESCRIPTION
Add README.md  in three subdirectories: dns/, python/, and go/.
Each README.md file explains the purpose of this subdirectory, how the library in that directory works, and how to use it.

Refs #2.