### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,23 @@
+name: Continuous Integration
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  compile:
+    name: Compile Java Module
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./java
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: maven
+      - name: Compile Tests
+        run: mvn test-compile

--- a/.github/workflows/publish-java-package.yml
+++ b/.github/workflows/publish-java-package.yml
@@ -1,0 +1,34 @@
+name: Publish the Java Package to Maven Central
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version (e.g. "2.1.5")'
+        required: true
+        type: string
+
+jobs:
+  compile:
+    name: Publish the Java Package to Maven Central
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./java
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+          cache: maven
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Publish
+        run: mvn -Drevision=${{ inputs.releaseVersion }} deploy
+        env:
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to the Alternator Load Balancing
+
+First off, thanks for taking the time to contribute!
+
+## Java package
+
+### Publish a new release to Maven Central
+
+On GitHub, go to the [publish Java package workflow](https://github.com/scylladb/alternator-load-balancing/actions/workflows/publish-java-package.yml) and click “Run workflow”. Enter the release version (e.g. “1.2.3”) and confirm.
+
+After the release, bump the `project.properties.revision` property in the `pom.xml` and add the suffix `-SNAPSHOT`. For instance, after the release of version `1.2.3`, set the revision to `1.2.4-SNAPSHOT`. 

--- a/java/README.md
+++ b/java/README.md
@@ -28,19 +28,38 @@ versions are still in popular use today, so the Alternator load balancing
 library described here supports both (our version 2 support requires 2.20
 or above).
 
-## The LoadBalancing jar
+## Add `load-balancing` to your project
+
+### Maven Dependency
+
+Add the `load-balancing` dependency to your Maven project by adding the
+following `dependency` to your `pom.xml` definition:
+
+~~~ xml
+<dependency>
+  <groupId>com.scylladb.alternator</groupId>
+  <artifactId>load-balancing</artifactId>
+  <version>1.0.0</version>
+</dependency>
+~~~
+
+You can find the latest version [here](https://central.sonatype.com/artifact/com.scylladb.alternator/load-balancing).
+
+### Alternatively, build the LoadBalancing jar
 To build a jar of the Alternator client-side load balancer, use
 ```
 mvn package
 ```
-Which creates `target/LoadBalancing-1.0.jar`.
+Which creates `target/load-balancing-1.0.0-SNAPSHOT.jar`.
 
-As explained above, this jar does not _replace_ the AWS SDK for Java, but
+## Usage
+
+As explained above, this package does not _replace_ the AWS SDK for Java, but
 accompanies it, and either version 1 or 2 of the AWS SDK for Java can be
 used (the details on how to use are slightly different for each version,
 so will be explained in separate sections below).
 
-As we show below, the jar provides a new mechanism to configure a
+As we show below, the package provides a new mechanism to configure a
 DynamoDB (v1) or DynamoDbClient (v2) object, which the application
 can then use normally using the standard AWS SDK for Java, to make
 requests. The load balancer library ensures that each of these requests
@@ -52,7 +71,7 @@ changes. It does this using an additional background thread, which
 periodically polls one of the known nodes, asking it for a list of all other
 nodes (in this data-center).
 
-## Using the library, in AWS SDK for Java v1
+### Using the library, in AWS SDK for Java v1
 
 An application using AWS SDK for Java v1 creates a `DynamoDB` object and then
 uses it to perform various requests. Traditionally, to create such an object,
@@ -116,7 +135,7 @@ After building with `mvn package`, you can run this demo with the command:
 mvn exec:java -Dexec.mainClass=com.scylladb.alternator.test.Demo1 -Dexec.classpathScope=test
 ```
 
-## Using the library, in AWS SDK for Java v2
+### Using the library, in AWS SDK for Java v2
 
 An application using AWS SDK for Java v2 creates a `DynamoDbClient` object
 and then uses it to perform various requests. Traditionally, to create such
@@ -178,7 +197,7 @@ After building with `mvn package`, you can run this demo with the command:
 mvn exec:java -Dexec.mainClass=com.scylladb.alternator.test.Demo2 -Dexec.classpathScope=test
 ```
 
-### Asyncronous operation in SDK v2
+#### Asyncronous operation in SDK v2
 
 When using SDK v2, you can achieve better scalability and performance using the asynchronous
 versions of API calls and `java.util.concurrent` completion chaining. 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -4,13 +4,17 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.scylladb.alternator</groupId>
-    <artifactId>LoadBalancing</artifactId>
-    <version>1.0</version>
+    <artifactId>load-balancing</artifactId>
+    <version>${revision}</version>
+    <name>Scylla Alternator client performing load balancing</name>
+    <description>DynamoDB client request handler balancing the load across all the nodes of a Scylla cluster</description>
+    <url>https://github.com/scylladb/alternator-load-balancing</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <revision>1.0.0-SNAPSHOT</revision>
     </properties>
 
     <dependencyManagement>
@@ -60,4 +64,84 @@
 		</dependency>        
         <!-- TODO: test also dynamodb-enhanced for v2: https://aws.amazon.com/blogs/developer/introducing-enhanced-dynamodb-client-in-the-aws-sdk-for-java-v2/ -->
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.3.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.6.3</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.2.4</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org</nexusUrl> <!-- TODO Check whether we should use s01.oss.sonatype.org instead -->
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose> <!-- TODO set to true after successful manual release -->
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
+    <licenses>
+        <license>
+            <name>The Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+    <scm>
+        <connection>scm:git:https://github.com/scylladb/alternator-load-balancing</connection>
+        <developerConnection>scm:git:https://github.com/scylladb/alternator-load-balancing</developerConnection>
+        <url>https://github.com/scylladb/alternator-load-balancing</url>
+        <tag>HEAD</tag>
+    </scm>
+    <developers>
+        <developer>
+            <name>Various</name>
+            <organization>ScyllaDB</organization>
+        </developer>
+    </developers>
 </project>


### PR DESCRIPTION
This PR is based on #17 and adds another workflow for publishing the Java artifacts (based on https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven).

To perform a release, the maintainers of this repository will have to trigger the release workflow from the [Actions](https://github.com/scylladb/alternator-load-balancing/actions) tab and set the release version from there (see the added file CONTRIBUTING.md). The workflow will build the jars and publish them to Sonatype, which requires credentials that need to be provided as repository secrets.

As reflected in the README.md, this will change the way users can reuse the load-balancing module: they will be able to add a regular library dependency on the artifact `com.scylladb.alternator:load-balancing` instead of manually building the jar and adding it to their project classpath.

After the PR is merged, I need someone to set up the secrets and to try the workflow (see the instructions here: https://central.sonatype.org/publish/publish-guide/).
