### PR TITLE
Remove excessive printouts

### DIFF
--- a/go/v1/alternator_lb.go
+++ b/go/v1/alternator_lb.go
@@ -139,7 +139,6 @@ func (this *AlternatorNodes) session(
 		fake_host := fmt.Sprintf("%s:%d", fake_domain, this.port)
 		if r.HTTPRequest.URL.Host == fake_host {
 			new_url := url.URL{Scheme: this.scheme, Host: fmt.Sprintf("%s:%d", this.pickone(), this.port)}
-			fmt.Printf("Alternator load balacing %s -> %s\n", r.HTTPRequest.URL.String(), new_url.String())
 			*r.HTTPRequest.URL = new_url
 			// The request is already signed with a signature including
 			// fake_host. We must set the "Host" header in the request

--- a/go/v2/alternator_lb.go
+++ b/go/v2/alternator_lb.go
@@ -152,7 +152,6 @@ func (n *AlternatorNodes) loadBalancerMiddleware(domain string) middleware.Final
 			if v.URL != nil && v.URL.Host == host {
 				pickedNode := n.pickNode()
 				new_url := url.URL{Scheme: n.scheme, Host: fmt.Sprintf("%s:%d", pickedNode, n.port)}
-				fmt.Printf("Alternator load balacing %s -> %s\n", v.URL.String(), new_url.String())
 				*v.URL = new_url
 				// The request is already signed with a signature including
 				// fake_host. We must set the "Host" header in the request

--- a/javascript/Alternator.js
+++ b/javascript/Alternator.js
@@ -28,7 +28,6 @@ agent.createConnection = function(options, callback = null) {
         if (hostname == FAKE_HOST) {
             var host = hosts[hostIdx];
             hostIdx = (hostIdx + 1) % hosts.length;
-            console.log("Picked", host);
             return dns.lookup(host, options, callback);
         }
         return dns.lookup(hostname, options, callback);
@@ -47,7 +46,6 @@ async function updateHosts() {
         resp.on('data', (payload) => {
             payload = JSON.parse(payload);
             hosts = payload;
-            console.log("Hosts updated to", hosts);
         });
     });
     await new Promise(r => setTimeout(r, 1000));

--- a/python/boto3_alternator.py
+++ b/python/boto3_alternator.py
@@ -122,7 +122,6 @@ def setup1(known_nodes, scheme, port, fake_domain):
         if (host == alternator_fake_domain):
             # TODO: consider whether random, or round-robin, is better.
             host = random.choice(livenodes)
-            print("picked {}".format(host))
         return orig_getaddrinfo(host, *args)
     socket.getaddrinfo = new_getaddrinfo
     return "{}://{}:{}".format(alternator_scheme, fake_domain, alternator_port)
@@ -157,7 +156,6 @@ def setup2(known_nodes, scheme, port, fake_domain):
             # TODO: consider whether random, or round-robin, is better.
             host = random.choice(livenodes)
             request.url = "{}://{}:{}/".format(alternator_scheme, host, alternator_port)
-            print("picked {}".format(request.url))
             # botocore does not set a "Host" header, but it turns out the
             # lower-level urllib3 library adds one automatically using the
             # connection's url, which we now changed to be an IP address.


### PR DESCRIPTION
This patch removes excessive printouts on the Go, Javascript and Python drivers. While printing every decision on every request is pretty for demonstrating the load balancing, it is annoying when used in production and can needlessly fill the logs.

As far as I can tell, the Java driver did not have such excessive printouts (it has logs in the FINE level, but those will be normally not visible).