### PR TITLE
adding distributionManagement section to java/pom.xml

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -126,6 +126,17 @@
         </profile>
     </profiles>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>


### PR DESCRIPTION
follow the error in publish workflow:
`failed: repository element was not specified in
the POM inside distributionManagement element`

adding distributionManagement section with snapshotRepository and repository to java/pom.xml