### PR TITLE
Fix the publish workflow

### DIFF
--- a/.github/workflows/publish-java-package.yml
+++ b/.github/workflows/publish-java-package.yml
@@ -27,7 +27,7 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish
-        run: mvn -Drevision=${{ inputs.releaseVersion }} deploy
+        run: mvn -Drevision=${{ inputs.releaseVersion }} clean deploy -Prelease
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}


### PR DESCRIPTION
Make sure to use the `release` Maven profile when running the Publish workflow to attach the Javadoc JAR and the sources to the release artifacts.