### PR TITLE
Fully automate the release process

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -117,8 +117,8 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org</nexusUrl> <!-- TODO Check whether we should use s01.oss.sonatype.org instead -->
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose> <!-- TODO set to true after successful manual release -->
+                            <nexusUrl>https://oss.sonatype.org</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Set `autoReleaseAfterClose` to `true` to automatically release successfully closed repositories on Sonatype.

This will make the release process fully automated (we only need to trigger the publish workflow and supply the release version)