### PR TITLE
Fix the version set in the pom.xml for a release

### DIFF
--- a/.github/workflows/publish-java-package.yml
+++ b/.github/workflows/publish-java-package.yml
@@ -27,7 +27,9 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish
-        run: mvn -Drevision=${{ inputs.releaseVersion }} clean deploy -Prelease
+        run: |
+          mvn versions:set -DnewVersion ${{ inputs.releaseVersion }}
+          mvn clean deploy -Prelease
         env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.scylladb.alternator</groupId>
     <artifactId>load-balancing</artifactId>
-    <version>${revision}</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>Scylla Alternator client performing load balancing</name>
     <description>DynamoDB client request handler balancing the load across all the nodes of a Scylla cluster</description>
     <url>https://github.com/scylladb/alternator-load-balancing</url>
@@ -14,7 +14,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <revision>1.0.0-SNAPSHOT</revision>
     </properties>
 
     <dependencyManagement>
@@ -155,4 +154,14 @@
             <organization>ScyllaDB</organization>
         </developer>
     </developers>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.17.1</version>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Although the publish workflow works, I noticed that the published pom.xml file still contains a confusing version number. See e.g.

https://repo1.maven.org/maven2/com/scylladb/alternator/load-balancing/1.0.0/load-balancing-1.0.0.pom

(Which incorrectly sets the version to `1.0.0-SNAPSHOT` instead of `1.0.0`)

This might be a problem because tooling may use the wrong version. See e.g.

https://central.sonatype.com/artifact/com.scylladb.alternator/load-balancing/versions

We fix that by using the `versions-maven-plugin` and changing the version in the pom.xml file before running the `deploy` command.

See the documentation: https://www.mojohaus.org/versions/versions-maven-plugin/set-mojo.html