### PR TITLE
golang: introduce headers optimization to reduce network footprint

### DIFF
--- a/go/common/config.go
+++ b/go/common/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	ClientCertificate     *CertSource
 	// Makes it ignore server certificate errors
 	IgnoreServerCertificateError bool
+	// OptimizeHeaders - when true removes unnecessary http headers reducing network footprint
+	OptimizeHeaders bool
 }
 
 type Option func(config *Config)
@@ -124,5 +126,11 @@ func WithClientCertificate(certificate tls.Certificate) Option {
 func WithIgnoreServerCertificateError() Option {
 	return func(config *Config) {
 		config.IgnoreServerCertificateError = true
+	}
+}
+
+func WithOptimizeHeaders() Option {
+	return func(config *Config) {
+		config.OptimizeHeaders = true
 	}
 }

--- a/go/common/header_whitelist.go
+++ b/go/common/header_whitelist.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"net/http"
+	"slices"
+	"strings"
+)
+
+type HeaderWhiteListing struct {
+	allowedHeaders []string
+	original       http.RoundTripper
+}
+
+func NewHeaderWhiteListing(original http.RoundTripper, allowedHeaders ...string) *HeaderWhiteListing {
+	for id, h := range allowedHeaders {
+		allowedHeaders[id] = strings.ToLower(h)
+	}
+	return &HeaderWhiteListing{
+		allowedHeaders: allowedHeaders,
+		original:       original,
+	}
+}
+
+func (h HeaderWhiteListing) RoundTrip(r *http.Request) (*http.Response, error) {
+	newHeaders := http.Header{}
+	for headerName := range r.Header {
+		if slices.Contains(h.allowedHeaders, strings.ToLower(headerName)) {
+			newHeaders.Set(headerName, r.Header.Get(headerName))
+		}
+	}
+	r.Header = newHeaders
+	return h.original.RoundTrip(r)
+}
+
+var _ http.RoundTripper = HeaderWhiteListing{}


### PR DESCRIPTION
This PR introduce configuration option `WithOptimizeHeaders` to the `AlternatorLB`.
When it is on, it makes it remove any headers except: `Host`, `X-Amz-Target`, `Content-Length`, `Accept-Encoding` and 
It also includes `Authorization` header to the whitelist when credentials are provided

@nyh, I don't see us using `X-Amz-Date`, so I have excluded it as well : https://github.com/scylladb/scylladb/blob/415e8de36e879c556480bf32585a0a16a2ff281f/alternator/server.cc#L270-L369

Let me know if I need to add it to the whitelist.

====== UPDATE =======
`X-Amz-Date` is whitelisted when user provides credentials, alongside with `Authorization`


