### PR TITLE
golang: introduce idle update period

### DIFF
--- a/go/common/config.go
+++ b/go/common/config.go
@@ -22,6 +22,8 @@ type Config struct {
 	IgnoreServerCertificateError bool
 	// OptimizeHeaders - when true removes unnecessary http headers reducing network footprint
 	OptimizeHeaders bool
+	// Update node list when no requests are running
+	IdleNodesListUpdatePeriod time.Duration
 }
 
 type Option func(config *Config)
@@ -34,10 +36,11 @@ const (
 
 func NewConfig() *Config {
 	return &Config{
-		Port:                  defaultPort,
-		Scheme:                defaultScheme,
-		AWSRegion:             defaultAWSRegion,
-		NodesListUpdatePeriod: 5 * time.Minute,
+		Port:                      defaultPort,
+		Scheme:                    defaultScheme,
+		AWSRegion:                 defaultAWSRegion,
+		NodesListUpdatePeriod:     5 * time.Minute,
+		IdleNodesListUpdatePeriod: 2 * time.Hour,
 	}
 }
 
@@ -58,6 +61,10 @@ func (c *Config) ToALNConfig() []ALNOption {
 
 	if c.ALNHTTPClient != nil {
 		out = append(out, WithALNHTTPClient(c.HTTPClient))
+	}
+
+	if c.IdleNodesListUpdatePeriod != 0 {
+		out = append(out, WithALNIdleUpdatePeriod(c.IdleNodesListUpdatePeriod))
 	}
 
 	return out
@@ -139,5 +146,11 @@ func WithIgnoreServerCertificateError() Option {
 func WithOptimizeHeaders() Option {
 	return func(config *Config) {
 		config.OptimizeHeaders = true
+	}
+}
+
+func WithIdleNodesListUpdatePeriod(period time.Duration) Option {
+	return func(config *Config) {
+		config.IdleNodesListUpdatePeriod = period
 	}
 }

--- a/go/v1/alternator_lb.go
+++ b/go/v1/alternator_lb.go
@@ -27,6 +27,7 @@ var (
 	WithDatacenter                   = common.WithDatacenter
 	WithAWSRegion                    = common.WithAWSRegion
 	WithNodesListUpdatePeriod        = common.WithNodesListUpdatePeriod
+	WithIdleNodesListUpdatePeriod    = common.WithIdleNodesListUpdatePeriod
 	WithCredentials                  = common.WithCredentials
 	WithHTTPClient                   = common.WithHTTPClient
 	WithLocalNodesReaderHTTPClient   = common.WithLocalNodesReaderHTTPClient
@@ -68,6 +69,14 @@ func (lb *AlternatorLB) CheckIfRackAndDatacenterSetCorrectly() error {
 
 func (lb *AlternatorLB) CheckIfRackDatacenterFeatureIsSupported() (bool, error) {
 	return lb.nodes.CheckIfRackDatacenterFeatureIsSupported()
+}
+
+func (lb *AlternatorLB) Start() {
+	lb.nodes.Start()
+}
+
+func (lb *AlternatorLB) Stop() {
+	lb.nodes.Stop()
 }
 
 // AWSConfig produces a conf for the AWS SDK that will integrate the alternator loadbalancing with the AWS SDK.

--- a/go/v1/alternator_lb_test.go
+++ b/go/v1/alternator_lb_test.go
@@ -16,6 +16,8 @@ func TestCheckIfRackAndDatacenterSetCorrectly_WrongDC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	if lb.CheckIfRackAndDatacenterSetCorrectly() == nil {
 		t.Fatalf("CheckIfRackAndDatacenterSetCorrectly() should have returned an error")
 	}
@@ -26,6 +28,8 @@ func TestCheckIfRackAndDatacenterSetCorrectly_CorrectDC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	if err := lb.CheckIfRackAndDatacenterSetCorrectly(); err != nil {
 		t.Fatalf("CheckIfRackAndDatacenterSetCorrectly() unexpectedly returned an error: %v", err)
 	}
@@ -36,6 +40,8 @@ func TestCheckIfRackAndDatacenterSetCorrectly_WrongRack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	if lb.CheckIfRackAndDatacenterSetCorrectly() == nil {
 		t.Fatalf("CheckIfRackAndDatacenterSetCorrectly() should have returned an error")
 	}
@@ -46,6 +52,8 @@ func TestCheckIfRackAndDatacenterSetCorrectly_CorrectRack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	if err := lb.CheckIfRackAndDatacenterSetCorrectly(); err != nil {
 		t.Fatalf("CheckIfRackAndDatacenterSetCorrectly() unexpectedly returned an error: %v", err)
 	}
@@ -56,6 +64,8 @@ func TestCheckIfRackDatacenterFeatureIsSupported(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	val, err := lb.CheckIfRackDatacenterFeatureIsSupported()
 	if err != nil {
 		t.Fatalf("CheckIfRackAndDatacenterSetCorrectly() unexpectedly returned an error: %v", err)
@@ -71,6 +81,8 @@ func TestDynamoDBOperations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	ddb, err := lb.WithCredentials("whatever", "secret").NewDynamoDB()
 	if err != nil {
 		t.Fatalf("Error creating dynamoDB client: %v", err)

--- a/go/v2/alternator_lb.go
+++ b/go/v2/alternator_lb.go
@@ -25,6 +25,7 @@ var (
 	WithDatacenter                   = common.WithDatacenter
 	WithAWSRegion                    = common.WithAWSRegion
 	WithNodesListUpdatePeriod        = common.WithNodesListUpdatePeriod
+	WithIdleNodesListUpdatePeriod    = common.WithIdleNodesListUpdatePeriod
 	WithCredentials                  = common.WithCredentials
 	WithHTTPClient                   = common.WithHTTPClient
 	WithLocalNodesReaderHTTPClient   = common.WithLocalNodesReaderHTTPClient
@@ -170,6 +171,14 @@ func (lb *AlternatorLB) CheckIfRackAndDatacenterSetCorrectly() error {
 
 func (lb *AlternatorLB) CheckIfRackDatacenterFeatureIsSupported() (bool, error) {
 	return lb.nodes.CheckIfRackDatacenterFeatureIsSupported()
+}
+
+func (lb *AlternatorLB) Start() {
+	lb.nodes.Start()
+}
+
+func (lb *AlternatorLB) Stop() {
+	lb.nodes.Stop()
 }
 
 func (lb *AlternatorLB) endpointResolverV2() dynamodb.EndpointResolverV2 {

--- a/go/v2/alternator_lb_test.go
+++ b/go/v2/alternator_lb_test.go
@@ -3,6 +3,7 @@ package alternator_loadbalancing_v2_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	alb "alternator_loadbalancing_v2"
 
@@ -19,6 +20,8 @@ func TestCheckIfRackAndDatacenterSetCorrectly_WrongDC(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	if lb.CheckIfRackAndDatacenterSetCorrectly() == nil {
 		t.Errorf("CheckIfRackAndDatacenterSetCorrectly() should have returned an error")
 	}
@@ -29,6 +32,8 @@ func TestCheckIfRackAndDatacenterSetCorrectly_CorrectDC(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	if err := lb.CheckIfRackAndDatacenterSetCorrectly(); err != nil {
 		t.Errorf("CheckIfRackAndDatacenterSetCorrectly() unexpectedly returned an error: %v", err)
 	}
@@ -39,6 +44,8 @@ func TestCheckIfRackAndDatacenterSetCorrectly_WrongRack(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	if lb.CheckIfRackAndDatacenterSetCorrectly() == nil {
 		t.Errorf("CheckIfRackAndDatacenterSetCorrectly() should have returned an error")
 	}
@@ -49,6 +56,8 @@ func TestCheckIfRackAndDatacenterSetCorrectly_CorrectRack(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	if err := lb.CheckIfRackAndDatacenterSetCorrectly(); err != nil {
 		t.Errorf("CheckIfRackAndDatacenterSetCorrectly() unexpectedly returned an error: %v", err)
 	}
@@ -59,6 +68,8 @@ func TestCheckIfRackDatacenterFeatureIsSupported(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	val, err := lb.CheckIfRackDatacenterFeatureIsSupported()
 	if err != nil {
 		t.Errorf("CheckIfRackAndDatacenterSetCorrectly() unexpectedly returned an error: %v", err)
@@ -70,10 +81,12 @@ func TestCheckIfRackDatacenterFeatureIsSupported(t *testing.T) {
 
 func TestDynamoDBOperations(t *testing.T) {
 	const tableName = "test_table"
-	lb, err := alb.NewAlternatorLB(knownNodes, alb.WithPort(9999))
+	lb, err := alb.NewAlternatorLB(knownNodes, alb.WithPort(9999), alb.WithIdleNodesListUpdatePeriod(1*time.Second))
 	if err != nil {
 		t.Errorf("Error creating alternator load balancer: %v", err)
 	}
+	defer lb.Stop()
+
 	ddb, err := lb.WithCredentials("whatever", "secret").NewDynamoDB()
 	if err != nil {
 		t.Errorf("Error creating dynamoDB client: %v", err)


### PR DESCRIPTION
Introduce option `IdleNodesListUpdatePeriod` to make lb code update node list even when there is no requests from user.

Closes gap for: https://github.com/scylladb/alternator-load-balancing/pull/97