### PR TITLE
golang: make dynamodb client retry on another host when http request failed

### DIFF
--- a/go/v1/alternator_lb_test.go
+++ b/go/v1/alternator_lb_test.go
@@ -3,10 +3,10 @@ package alternator_loadbalancing_test
 import (
 	"testing"
 
-	alb "alternator_loadbalancing"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/dynamodb"
+
+	alb "alternator_loadbalancing"
 )
 
 var knownNodes = []string{"172.17.0.2"}

--- a/go/v2/alternator_lb_test.go
+++ b/go/v2/alternator_lb_test.go
@@ -3,14 +3,13 @@ package alternator_loadbalancing_v2_test
 import (
 	"context"
 	"testing"
-	"time"
-
-	alb "alternator_loadbalancing_v2"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	alb "alternator_loadbalancing_v2"
 )
 
 var knownNodes = []string{"172.17.0.2"}
@@ -81,7 +80,7 @@ func TestCheckIfRackDatacenterFeatureIsSupported(t *testing.T) {
 
 func TestDynamoDBOperations(t *testing.T) {
 	const tableName = "test_table"
-	lb, err := alb.NewAlternatorLB(knownNodes, alb.WithPort(9999), alb.WithIdleNodesListUpdatePeriod(1*time.Second))
+	lb, err := alb.NewAlternatorLB(knownNodes, alb.WithPort(9999))
 	if err != nil {
 		t.Errorf("Error creating alternator load balancer: %v", err)
 	}


### PR DESCRIPTION
It is needed to address scenario when node is dead or decomissioned. 
We need to make sure that when http request is failed it is being retried on another host, if available.
`AWS SDK v1` retries on the same host, to address that we need to move host picking logic into `http.Transport` layer.
`AWS SDK v2` works just fine.

Fixes https://github.com/scylladb/alternator-load-balancing/issues/99