### PR TITLE
Golang: add feature to extract pre master key secrets

### DIFF
--- a/go/common/utils.go
+++ b/go/common/utils.go
@@ -22,17 +22,19 @@ func NewHTTPTransport(config ALNConfig) *http.Transport {
 }
 
 func PatchBasicHTTPTransport(config ALNConfig, transport *http.Transport) {
-	needsToBePatched := config.IgnoreServerCertificateError || config.ClientCertificateSource != nil
-
 	transport.IdleConnTimeout = defaultIdleConnectionTimeout
 	transport.MaxIdleConns = 100
 
-	if !needsToBePatched {
+	if !config.IgnoreServerCertificateError && config.ClientCertificateSource == nil && config.KeyLogWriter == nil {
 		return
 	}
 
 	if transport.TLSClientConfig == nil {
 		transport.TLSClientConfig = &tls.Config{}
+	}
+
+	if config.KeyLogWriter != nil {
+		transport.TLSClientConfig.KeyLogWriter = config.KeyLogWriter
 	}
 
 	if config.IgnoreServerCertificateError {
@@ -49,8 +51,4 @@ func PatchBasicHTTPTransport(config ALNConfig, transport *http.Transport) {
 
 func LogError(err error) {
 	_, _ = fmt.Fprintf(os.Stderr, "ERROR: %s", err.Error())
-}
-
-func LogErrorf(format string, args ...interface{}) {
-	_, _ = fmt.Fprintf(os.Stderr, "ERROR:"+format, args...)
 }

--- a/go/v1/README.md
+++ b/go/v1/README.md
@@ -89,6 +89,22 @@ func main() {
 }
 ```
 
+## Decrypting TLS
+
+Read wireshark wiki regarding decrypting TLS traffic: https://wiki.wireshark.org/TLS#using-the-pre-master-secret
+In order to obtain pre master key secrets, you need to provide a file writer into `alb.WithKeyLogWriter`, example:
+
+```go
+	keyWriter, err := os.OpenFile("/tmp/pre-master-key.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+    if err != nil {
+        panic("Error opening key writer: " + err.Error())
+	}
+	defer keyWriter.Close()
+	lb, err := alb.NewAlternatorLB(knownNodes, alb.WithScheme("https"), alb.WithPort(httpsPort), alb.WithIgnoreServerCertificateError(true), alb.WithKeyLogWriter(keyWriter))
+```
+
+Then you need to configure your traffic analyzer to read pre master key secrets from this file.
+
 ## Example
 
 You can find examples in `[alternator_lb_test.go](alternator_lb_test.go)`

--- a/go/v1/alternator_lb.go
+++ b/go/v1/alternator_lb.go
@@ -30,6 +30,7 @@ var (
 	WithClientCertificateSource      = common.WithClientCertificateSource
 	WithIgnoreServerCertificateError = common.WithIgnoreServerCertificateError
 	WithOptimizeHeaders              = common.WithOptimizeHeaders
+	WithKeyLogWriter                 = common.WithKeyLogWriter
 )
 
 type AlternatorLB struct {
@@ -56,6 +57,10 @@ func NewAlternatorLB(initialNodes []string, options ...Option) (*AlternatorLB, e
 
 func (lb *AlternatorLB) NextNode() url.URL {
 	return lb.nodes.NextNode()
+}
+
+func (lb *AlternatorLB) UpdateLiveNodes() error {
+	return lb.nodes.UpdateLiveNodes()
 }
 
 func (lb *AlternatorLB) CheckIfRackAndDatacenterSetCorrectly() error {

--- a/go/v1/alternator_lb_test.go
+++ b/go/v1/alternator_lb_test.go
@@ -4,6 +4,7 @@
 package alternator_loadbalancing_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -88,6 +89,64 @@ func TestDynamoDBOperations(t *testing.T) {
 	})
 	t.Run("SSL", func(t *testing.T) {
 		testDynamoDBOperations(t, alb.WithScheme("https"), alb.WithPort(httpsPort), alb.WithIgnoreServerCertificateError(true))
+	})
+}
+
+type KeyWriter struct {
+	keyData []byte
+}
+
+func (w *KeyWriter) Write(p []byte) (int, error) {
+	w.keyData = append(w.keyData, p...)
+	return len(p), nil
+}
+
+func TestKeyLogWriter(t *testing.T) {
+	opts := []alb.Option{
+		alb.WithScheme("https"),
+		alb.WithPort(httpsPort),
+		alb.WithIgnoreServerCertificateError(true),
+		alb.WithNodesListUpdatePeriod(0),
+		alb.WithIdleNodesListUpdatePeriod(0),
+	}
+	t.Run("KeyFromAlternatorLiveNodes", func(t *testing.T) {
+		keyWriter := &KeyWriter{}
+		lb, err := alb.NewAlternatorLB(knownNodes, append(slices.Clone(opts), alb.WithKeyLogWriter(keyWriter))...)
+		if err != nil {
+			t.Fatalf("Error creating alternator load balancer: %v", err)
+		}
+		defer lb.Stop()
+
+		err = lb.UpdateLiveNodes()
+		if err != nil {
+			t.Fatalf("UpdateLiveNodes() unexpectedly returned an error: %v", err)
+		}
+
+		if len(keyWriter.keyData) == 0 {
+			t.Fatalf("keyData should not be empty")
+		}
+	})
+
+	t.Run("KeyFromAPI", func(t *testing.T) {
+		keyWriter := &KeyWriter{}
+		lb, err := alb.NewAlternatorLB(knownNodes, append(slices.Clone(opts), alb.WithKeyLogWriter(keyWriter))...)
+		if err != nil {
+			t.Fatalf("Error creating alternator load balancer: %v", err)
+		}
+		defer lb.Stop()
+
+		ddb, err := lb.NewDynamoDB()
+		if err != nil {
+			t.Fatalf("Error creating dynamoDB client: %v", err)
+		}
+
+		_, _ = ddb.DeleteTable(&dynamodb.DeleteTableInput{
+			TableName: aws.String("table-that-does-not-exist"),
+		})
+
+		if len(keyWriter.keyData) == 0 {
+			t.Fatalf("keyData should not be empty")
+		}
 	})
 }
 

--- a/go/v2/README.md
+++ b/go/v2/README.md
@@ -90,6 +90,22 @@ func main() {
 }
 ```
 
+## Decrypting TLS
+
+Read wireshark wiki regarding decrypting TLS traffic: https://wiki.wireshark.org/TLS#using-the-pre-master-secret
+In order to obtain pre master key secrets, you need to provide a file writer into `alb.WithKeyLogWriter`, example:
+
+```go
+	keyWriter, err := os.OpenFile("/tmp/pre-master-key.log", os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+    if err != nil {
+        panic("Error opening key writer: " + err.Error())
+	}
+	defer keyWriter.Close()
+	lb, err := alb.NewAlternatorLB(knownNodes, alb.WithScheme("https"), alb.WithPort(httpsPort), alb.WithIgnoreServerCertificateError(true), alb.WithKeyLogWriter(keyWriter))
+```
+
+Then you need to configure your traffic analyzer to read pre master key secrets from this file.
+
 ## Example
 
 You can find examples in `[alternator_lb_test.go](alternator_lb_test.go)`

--- a/go/v2/alternator_lb.go
+++ b/go/v2/alternator_lb.go
@@ -32,6 +32,7 @@ var (
 	WithClientCertificateSource      = common.WithClientCertificateSource
 	WithIgnoreServerCertificateError = common.WithIgnoreServerCertificateError
 	WithOptimizeHeaders              = common.WithOptimizeHeaders
+	WithKeyLogWriter                 = common.WithKeyLogWriter
 )
 
 type AlternatorLB struct {
@@ -109,6 +110,10 @@ func (lb *AlternatorLB) WithAWSRegion(region string) *AlternatorLB {
 
 func (lb *AlternatorLB) NextNode() url.URL {
 	return lb.nodes.NextNode()
+}
+
+func (lb *AlternatorLB) UpdateLiveNodes() error {
+	return lb.nodes.UpdateLiveNodes()
 }
 
 func (lb *AlternatorLB) CheckIfRackAndDatacenterSetCorrectly() error {


### PR DESCRIPTION
In order to decrypt tls traffic it is needed to store pre master key secrets and feed them to traffic analyzer.
This commit introduces `WithKeyLogWriter` to get it done.