### PR TITLE
Golang: add tls session resumption support

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -107,7 +107,7 @@ integration-test: scylla-up
 
 .PHONY: .prepare-cert
 .prepare-cert:
-	@[ -f "test/scylla/db.key" ] || (echo "Prepare certificate" && cd test/scylla/ && openssl req -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" -x509 -newkey rsa:4096 -keyout db.key -out db.crt -days 3650 -nodes)
+	@[ -f "test/scylla/db.key" ] || (echo "Prepare certificate" && cd test/scylla/ && openssl req -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" -x509 -newkey rsa:4096 -keyout db.key -out db.crt -days 3650 -nodes && chmod 644 db.key)
 
 .PHONY: scylla-up
 scylla-up: .prepare-cert $(GOBIN)/docker-compose

--- a/go/common/cert_source.go
+++ b/go/common/cert_source.go
@@ -3,7 +3,6 @@ package common
 import (
 	"crypto/tls"
 	"fmt"
-	"net/http"
 	"os"
 	"sync"
 	"time"
@@ -65,13 +64,4 @@ func (c *CertSource) GetCertificate() (*tls.Certificate, error) {
 	c.cert = &cert
 	c.modTime = certStat.ModTime()
 	return c.cert, nil
-}
-
-func (c *CertSource) PatchHTTPTransport(transport *http.Transport) {
-	if transport.TLSClientConfig == nil {
-		transport.TLSClientConfig = &tls.Config{}
-	}
-	transport.TLSClientConfig.GetClientCertificate = func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-		return c.GetCertificate()
-	}
 }

--- a/go/v1/alternator_lb.go
+++ b/go/v1/alternator_lb.go
@@ -31,6 +31,8 @@ var (
 	WithIgnoreServerCertificateError = common.WithIgnoreServerCertificateError
 	WithOptimizeHeaders              = common.WithOptimizeHeaders
 	WithKeyLogWriter                 = common.WithKeyLogWriter
+	WithTLSSessionCache              = common.WithTLSSessionCache
+	WithMaxIdleHTTPConnections       = common.WithMaxIdleHTTPConnections
 )
 
 type AlternatorLB struct {

--- a/go/v2/alternator_lb.go
+++ b/go/v2/alternator_lb.go
@@ -33,6 +33,8 @@ var (
 	WithIgnoreServerCertificateError = common.WithIgnoreServerCertificateError
 	WithOptimizeHeaders              = common.WithOptimizeHeaders
 	WithKeyLogWriter                 = common.WithKeyLogWriter
+	WithTLSSessionCache              = common.WithTLSSessionCache
+	WithMaxIdleHTTPConnections       = common.WithMaxIdleHTTPConnections
 )
 
 type AlternatorLB struct {


### PR DESCRIPTION
It enables TLS session resumption by default.
And provides ability to override session cache
Tests are disabled because no scylla release available that supports this feature yet.

Fixes: https://github.com/scylladb/alternator-load-balancing/issues/92