### PR TITLE
Add python cicd

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,47 @@
+name: 'Python - Tests'
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - python/**
+  pull_request:
+    branches: [ master ]
+    paths:
+      - python/**
+  workflow_dispatch:
+
+defaults:
+  run:
+    working-directory: ./python
+jobs:
+  test:
+    name: Python - Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Run linters
+        run: |
+          make check
+
+      - name: Run unit tests
+        run: |
+          make unit-test
+
+      - name: Run integration tests
+        run: |
+          make integration-test
+
+      - name: Stop the cluster
+        if: ${{ always() }}
+        run: |
+         make scylla-kill

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ csharp/**/[Bb]uild[Ll]og.*
 go/bin/
 go/test/scylla/db.crt
 go/test/scylla/db.key
+
+python/bin/
+python/docker/scylla/db.crt
+python/docker/scylla/db.key

--- a/go/test/docker-compose.yml
+++ b/go/test/docker-compose.yml
@@ -1,6 +1,6 @@
 networks:
   public:
-    name: alternator_load_balancer_golang_network
+    name: alb_golang_network
     driver: bridge
     ipam:
       driver: default

--- a/python/Makefile
+++ b/python/Makefile
@@ -1,0 +1,105 @@
+define dl_tgz
+	@if ! $(1) 2>/dev/null 1>&2; then \
+		[ -d "$(BIN)" ] || mkdir "$(BIN)"; \
+		if [ ! -f "$(BIN)/$(1)" ]; then \
+			echo "Downloading $(BIN)/$(1)"; \
+			curl --progress-bar -L $(2) | tar zxf - --wildcards --strip 1 -C $(BIN) '*/$(1)'; \
+			chmod +x "$(BIN)/$(1)"; \
+		fi; \
+	fi
+endef
+
+define dl_bin
+	@if ! $(1) 2>/dev/null 1>&2; then \
+		[ -d "$(BIN)" ] || mkdir "$(BIN)"; \
+		if [ ! -f "$(BIN)/$(1)" ]; then \
+			echo "Downloading $(BIN)/$(1)"; \
+			curl --progress-bar -L $(2) --output "$(BIN)/$(1)"; \
+			chmod +x "$(BIN)/$(1)"; \
+		fi; \
+	fi
+endef
+
+MAKEFILE_PATH := $(abspath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
+DOCKER_COMPOSE_VERSION := 2.34.0
+ARCH := $(shell uname -m)
+OS := $(shell uname -s | tr A-Z a-z)
+
+ifndef BIN
+export BIN := $(MAKEFILE_PATH)/bin
+endif
+
+export PATH := $(BIN):$(PATH)
+
+
+DOCKER_COMPOSE_DOWNLOAD_URL := "https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-$(OS)-$(ARCH)"
+
+COMPOSE := docker-compose -f $(MAKEFILE_PATH)/docker/docker-compose.yml
+
+.PHONY: check
+check: check-autopep8 check-ruff
+
+.PHONY: fix
+fix: fix-autopep8 fix-ruff
+
+.PHONY: .prepare
+.prepare:
+	@echo "======== Check and install missing dependencies"
+	@pip install -r ./requirement-test.txt
+
+.PHONY: check-autopep8
+check-autopep8: .prepare
+	@echo "======== Running autopep8 check"
+	@autopep8 -r --diff ./
+
+.PHONY: check-ruff
+check-ruff: .prepare
+	@echo "======== Running ruff check"
+	@ruff check
+
+.PHONY: fix-autopep8
+fix-autopep8: .prepare
+	@echo "======== Running autopep8 fix"
+	@autopep8 -r -j 4 -i ./
+
+.PHONY: fix-ruff
+fix-ruff: .prepare
+	@echo "======== Running ruff fix"
+	@ruff check --fix --preview
+
+.PHONY: test
+test: unit-test integration-test
+
+.PHONY: unit-test
+unit-test:
+	@echo "======== Running unit tests"
+	@pytest ./test_unit*
+
+.PHONY: integration-test
+integration-test: scylla-up
+	@echo "======== Running integration tests"
+	@pytest ./test_integration*
+
+.PHONY: .prepare-cert
+.prepare-cert:
+	@[ -f "docker/scylla/db.key" ] || (echo "Prepare certificate" && cd docker/scylla/ && openssl req -subj "/C=US/ST=Denial/L=Springfield/O=Dis/CN=www.example.com" -x509 -newkey rsa:4096 -keyout db.key -out db.crt -days 3650 -nodes)
+
+.PHONY: scylla-up
+scylla-up: .prepare-cert $(BIN)/docker-compose
+	@sudo sysctl -w fs.aio-max-nr=10485760
+	$(COMPOSE) up -d
+
+.PHONY: scylla-down
+scylla-down: $(BIN)/docker-compose
+	$(COMPOSE) down
+
+.PHONY: scylla-kill
+scylla-kill: $(BIN)/docker-compose
+	$(COMPOSE) kill
+
+.PHONY: scylla-clean
+scylla-clean: $(BIN)/docker-compose scylla-kill
+	$(COMPOSE) rm
+
+$(BIN)/docker-compose: Makefile
+	$(call dl_bin,docker-compose,$(DOCKER_COMPOSE_DOWNLOAD_URL))

--- a/python/README.md
+++ b/python/README.md
@@ -31,7 +31,7 @@ This library periodically syncs list of active nodes with the cluster.
 import alternator_lb
 
 lb = alternator_lb.AlternatorLB(['x.x.x.x'], port=9999)
-dynamodb = lb.new_dynamodb_client()
+dynamodb = lb.new_botocore_dynamodb_client()
 
 dynamodb.delete_table(TableName="SomeTable")
 ```

--- a/python/alternator_lb.py
+++ b/python/alternator_lb.py
@@ -1,13 +1,12 @@
-import concurrent
 import threading
 import time
 import logging
 import requests
 
-from concurrent.futures import ThreadPoolExecutor
 from typing import List
 from urllib.parse import urlparse, urlunparse
 from dataclasses import dataclass
+from concurrent.futures import ThreadPoolExecutor
 
 
 class ExecutorPool:
@@ -18,7 +17,7 @@ class ExecutorPool:
 
     @staticmethod
     def create_executor():
-        return concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        return ThreadPoolExecutor(max_workers=1)
 
     def add_ref(self):
         with self._lock:
@@ -47,20 +46,20 @@ class Config:
     datacenter: str = None
     rack: str = None
     aws_region_name: str = "fake-alternator-lb-region"
-    aws_access_key_id: str = None
-    aws_secret_access_key: str = None
+    aws_access_key_id: str = "fake-alternator-lb-access-key-id"
+    aws_secret_access_key: str = "fake-alternator-lb-secret-access-key"
     update_interval: int = 10
 
     def _get_nodes(self) -> List[str]:
         nodes = []
         for node in self.nodes:
-            uri = urlunparse((self.schema, node + ":" + str(self.port), "", "", "", ""))
+            uri = urlunparse((self.schema, node + ":" +
+                             str(self.port), "", "", "", ""))
             parsed_uri = urlparse(uri)
             if not parsed_uri.scheme or not parsed_uri.netloc:
                 raise ValueError(f"Invalid URI: {uri}")
             nodes.append(uri)
         return nodes
-
 
 
 class AlternatorLB:
@@ -126,7 +125,8 @@ class AlternatorLB:
     def _next_alternator_node(self) -> str:
         self._update_nodes_if_needed()
         with self._live_nodes_lock:
-            node = self._live_nodes[self._next_live_node_index % len(self._live_nodes)]
+            node = self._live_nodes[self._next_live_node_index % len(
+                self._live_nodes)]
             self._next_live_node_index += 1
             return node
 
@@ -137,11 +137,13 @@ class AlternatorLB:
 
         node = None
         with self._live_nodes_lock:
-            node = self._live_nodes[self._next_live_node_index % len(self._live_nodes)]
+            node = self._live_nodes[self._next_live_node_index % len(
+                self._live_nodes)]
 
         self._next_live_node_index += 1
         parsed = urlparse(node)
-        new_uri = urlunparse((parsed.scheme, parsed.netloc, path, "", query, ""))
+        new_uri = urlunparse(
+            (parsed.scheme, parsed.netloc, path, "", query, ""))
         return new_uri
 
     def _update_live_nodes(self):
@@ -183,7 +185,8 @@ class AlternatorLB:
 
         nodes = self._get_nodes(self._next_as_local_nodes_uri())
         if not nodes:
-            raise ValueError("Node returned empty list, datacenter or rack are set incorrectly")
+            raise ValueError(
+                "Node returned empty list, datacenter or rack are set incorrectly")
 
     def check_if_rack_datacenter_feature_is_supported(self) -> bool:
         uri = self._next_as_uri("/localnodes")
@@ -201,8 +204,9 @@ class AlternatorLB:
         with self._live_nodes_lock:
             return self._live_nodes[:]
 
-    def new_dynamodb_client(self, key: str = "", secret: str = "", region: str = "") -> object:
+    def new_botocore_dynamodb_client(self, key: str = "", secret: str = "", region: str = "") -> object:
         import botocore.session
+
         session = botocore.session.get_session()
         if not secret:
             secret = self._config.aws_secret_access_key
@@ -210,7 +214,24 @@ class AlternatorLB:
             key = self._config.aws_access_key_id
         if not region:
             region = self._config.aws_region_name
-        ddb = session.create_client('dynamodb', region_name=region, aws_access_key_id=key, aws_secret_access_key=secret)
+
+        ddb = session.create_client(
+            'dynamodb', region_name=region, aws_access_key_id=key, aws_secret_access_key=secret)
+        self.patch_dynamodb_client(ddb)
+        return ddb
+
+    def new_boto3_dynamodb_client(self, key: str = "", secret: str = "", region: str = "") -> object:
+        import boto3.session
+
+        if not secret:
+            secret = self._config.aws_secret_access_key
+        if not key:
+            key = self._config.aws_access_key_id
+        if not region:
+            region = self._config.aws_region_name
+
+        ddb = boto3.client('dynamodb', region_name=region,
+                           aws_access_key_id=key, aws_secret_access_key=secret)
         self.patch_dynamodb_client(ddb)
         return ddb
 
@@ -219,15 +240,18 @@ class AlternatorLB:
 
         current_resolver = getattr(client, '_ruleset_resolver', None)
         if not current_resolver:
-            raise Exception("looks like client is not a boto DynamoDB client, it has no _ruleset_resolver")
+            raise Exception(
+                "looks like client is not a boto DynamoDB client, it has no _ruleset_resolver")
         if current_resolver.__class__ != EndpointRulesetResolver:
             raise Exception("client._ruleset_resolver has unexpected class.")
 
         try:
             if not client.meta.config.region_name:
-                raise ValueError("client can't work properly with empty region name")
+                raise ValueError(
+                    "client can't work properly with empty region name")
         except AttributeError:
-            raise Exception("client has no meta.config.region_name, looks like it's not a botocore DynamoDB client.")
+            raise Exception(
+                "client has no meta.config.region_name, looks like it's not a botocore DynamoDB client.")
 
         orig = current_resolver.construct_endpoint
 
@@ -246,4 +270,3 @@ class AlternatorLB:
                 headers=endpoint_info.headers)
 
         setattr(current_resolver, 'construct_endpoint', construct_endpoint)
-

--- a/python/docker/docker-compose.yml
+++ b/python/docker/docker-compose.yml
@@ -1,0 +1,88 @@
+networks:
+  public:
+    name: alb_python_network
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.43.0.0/16
+
+services:
+  scylla1:
+    image: scylladb/scylla:2025.1
+    networks:
+      public:
+        ipv4_address: 172.43.0.2
+    command: |
+      --rpc-address 172.43.0.2
+      --listen-address 172.43.0.2
+      --seeds 172.43.0.2
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 2
+      --memory 1G
+    healthcheck:
+      test: [ "CMD", "cqlsh", "scylla1", "-e", "select * from system.local WHERE key='local'" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "19042"
+      - "9999"
+      - "9998"
+    volumes:
+      - ./scylla:/etc/scylla
+  scylla2:
+    image: scylladb/scylla:2025.1
+    networks:
+      public:
+        ipv4_address: 172.43.0.3
+    command: |
+      --rpc-address 172.43.0.3
+      --listen-address 172.43.0.3
+      --seeds 172.43.0.2
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 2
+      --memory 1G
+    healthcheck:
+      test: [ "CMD", "cqlsh", "scylla2", "-e", "select * from system.local WHERE key='local'" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "19042"
+      - "9999"
+      - "9998"
+    depends_on:
+      scylla1:
+        condition: service_healthy
+    volumes:
+      - ./scylla:/etc/scylla
+  scylla3:
+    image: scylladb/scylla:2025.1
+    networks:
+      public:
+        ipv4_address: 172.43.0.4
+    command: |
+      --rpc-address 172.43.0.4
+      --listen-address 172.43.0.4
+      --seeds 172.43.0.2,172.43.0.3
+      --skip-wait-for-gossip-to-settle 0
+      --ring-delay-ms 0
+      --smp 2
+      --memory 1G
+    healthcheck:
+      test: [ "CMD", "cqlsh", "scylla3", "-e", "select * from system.local WHERE key='local'" ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "19042"
+      - "9999"
+      - "9998"
+    depends_on:
+      scylla2:
+        condition: service_healthy
+    volumes:
+      - ./scylla:/etc/scylla

--- a/python/docker/scylla/scylla.yaml
+++ b/python/docker/scylla/scylla.yaml
@@ -1,0 +1,631 @@
+# Scylla storage config YAML
+
+#######################################
+# This file is split to two sections:
+# 1. Supported parameters
+# 2. Unsupported parameters: reserved for future use or backwards
+#    compatibility.
+# Scylla will only read and use the first segment
+#######################################
+
+### Supported Parameters
+
+# The name of the cluster. This is mainly used to prevent machines in
+# one logical cluster from joining another.
+# It is recommended to change the default value when creating a new cluster.
+# You can NOT modify this value for an existing cluster
+#cluster_name: 'Test Cluster'
+
+# This defines the number of tokens randomly assigned to this node on the ring
+# The more tokens, relative to other nodes, the larger the proportion of data
+# that this node will store. You probably want all nodes to have the same number
+# of tokens assuming they have equal hardware capability.
+num_tokens: 256
+
+# Directory where Scylla should store all its files, which are commitlog,
+# data, hints, view_hints and saved_caches subdirectories. All of these
+# subs can be overridden by the respective options below.
+# If unset, the value defaults to /var/lib/scylla
+# workdir: /var/lib/scylla
+
+# Directory where Scylla should store data on disk.
+# data_file_directories:
+#    - /var/lib/scylla/data
+
+# commit log.  when running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# commitlog_directory: /var/lib/scylla/commitlog
+
+# schema commit log. A special commitlog instance
+# used for schema and system tables.
+# When running on magnetic HDD, this should be a
+# separate spindle than the data directories.
+# schema_commitlog_directory: /var/lib/scylla/commitlog/schema
+
+# commitlog_sync may be either "periodic" or "batch."
+#
+# When in batch mode, Scylla won't ack writes until the commit log
+# has been fsynced to disk.  It will wait
+# commitlog_sync_batch_window_in_ms milliseconds between fsyncs.
+# This window should be kept short because the writer threads will
+# be unable to do extra work while waiting.  (You may need to increase
+# concurrent_writes for the same reason.)
+#
+# commitlog_sync: batch
+# commitlog_sync_batch_window_in_ms: 2
+#
+# the other option is "periodic" where writes may be acked immediately
+# and the CommitLog is simply synced every commitlog_sync_period_in_ms
+# milliseconds.
+commitlog_sync: periodic
+commitlog_sync_period_in_ms: 10000
+
+# The size of the individual commitlog file segments.  A commitlog
+# segment may be archived, deleted, or recycled once all the data
+# in it (potentially from each columnfamily in the system) has been
+# flushed to sstables.
+#
+# The default size is 32, which is almost always fine, but if you are
+# archiving commitlog segments (see commitlog_archiving.properties),
+# then you probably want a finer granularity of archiving; 8 or 16 MB
+# is reasonable.
+commitlog_segment_size_in_mb: 32
+
+# The size of the individual schema commitlog file segments.
+#
+# The default size is 128, which is 4 times larger than the default
+# size of the data commitlog. It's because the segment size puts
+# a limit on the mutation size that can be written at once, and some
+# schema mutation writes are much larger than average.
+schema_commitlog_segment_size_in_mb: 128
+
+# seed_provider class_name is saved for future use.
+# A seed address is mandatory.
+seed_provider:
+    # The addresses of hosts that will serve as contact points for the joining node.
+    # It allows the node to discover the cluster ring topology on startup (when
+    # joining the cluster).
+    # Once the node has joined the cluster, the seed list has no function.
+    - class_name: org.apache.cassandra.locator.SimpleSeedProvider
+      parameters:
+          # In a new cluster, provide the address of the first node.
+          # In an existing cluster, specify the address of at least one existing node.
+          # If you specify addresses of more than one node, use a comma to separate them.
+          # For example: "<IP1>,<IP2>,<IP3>"
+          - seeds: "127.0.0.1"
+
+# Address to bind to and tell other Scylla nodes to connect to.
+# You _must_ change this if you want multiple nodes to be able to communicate!
+#
+# If you leave broadcast_address (below) empty, then setting listen_address
+# to 0.0.0.0 is wrong as other nodes will not know how to reach this node.
+# If you set broadcast_address, then you can set listen_address to 0.0.0.0.
+listen_address: localhost
+
+# Address to broadcast to other Scylla nodes
+# Leaving this blank will set it to the same value as listen_address
+# broadcast_address: 1.2.3.4
+
+
+# When using multiple physical network interfaces, set this to true to listen on broadcast_address
+# in addition to the listen_address, allowing nodes to communicate in both interfaces.
+# Ignore this property if the network configuration automatically routes between the public and private networks such as EC2.
+#
+# listen_on_broadcast_address: false
+
+# port for the CQL native transport to listen for clients on
+# For security reasons, you should not expose this port to the internet. Firewall it if needed.
+# To disable the CQL native transport, remove this option and configure native_transport_port_ssl.
+native_transport_port: 9042
+
+# Like native_transport_port, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+native_shard_aware_transport_port: 19042
+
+# Enabling native transport encryption in client_encryption_options allows you to either use
+# encryption for the standard port or to use a dedicated, additional port along with the unencrypted
+# standard native_transport_port.
+# Enabling client encryption and keeping native_transport_port_ssl disabled will use encryption
+# for native_transport_port. Setting native_transport_port_ssl to a different value
+# from native_transport_port will use encryption for native_transport_port_ssl while
+# keeping native_transport_port unencrypted.
+native_transport_port_ssl: 9142
+
+# Like native_transport_port_ssl, but clients are forwarded to specific shards, based on the
+# client-side port numbers.
+native_shard_aware_transport_port_ssl: 19142
+
+# How long the coordinator should wait for read operations to complete
+read_request_timeout_in_ms: 5000
+
+# How long the coordinator should wait for writes to complete
+write_request_timeout_in_ms: 2000
+# how long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+cas_contention_timeout_in_ms: 1000
+
+# phi value that must be reached for a host to be marked down.
+# most users should never need to adjust this.
+# phi_convict_threshold: 8
+
+# IEndpointSnitch.  The snitch has two functions:
+# - it teaches Scylla enough about your network topology to route
+#   requests efficiently
+# - it allows Scylla to spread replicas around your cluster to avoid
+#   correlated failures. It does this by grouping machines into
+#   "datacenters" and "racks."  Scylla will do its best not to have
+#   more than one replica on the same "rack" (which may not actually
+#   be a physical location)
+#
+# IF YOU CHANGE THE SNITCH AFTER DATA IS INSERTED INTO THE CLUSTER,
+# YOU MUST RUN A FULL REPAIR, SINCE THE SNITCH AFFECTS WHERE REPLICAS
+# ARE PLACED.
+#
+# Out of the box, Scylla provides
+#  - SimpleSnitch:
+#    Treats Strategy order as proximity. This can improve cache
+#    locality when disabling read repair.  Only appropriate for
+#    single-datacenter deployments.
+#  - GossipingPropertyFileSnitch
+#    This should be your go-to snitch for production use.  The rack
+#    and datacenter for the local node are defined in
+#    cassandra-rackdc.properties and propagated to other nodes via
+#    gossip.  If cassandra-topology.properties exists, it is used as a
+#    fallback, allowing migration from the PropertyFileSnitch.
+#  - PropertyFileSnitch:
+#    Proximity is determined by rack and data center, which are
+#    explicitly configured in cassandra-topology.properties.
+#  - Ec2Snitch:
+#    Appropriate for EC2 deployments in a single Region. Loads Region
+#    and Availability Zone information from the EC2 API. The Region is
+#    treated as the datacenter, and the Availability Zone as the rack.
+#    Only private IPs are used, so this will not work across multiple
+#    Regions.
+#  - Ec2MultiRegionSnitch:
+#    Uses public IPs as broadcast_address to allow cross-region
+#    connectivity.  (Thus, you should set seed addresses to the public
+#    IP as well.) You will need to open the storage_port or
+#    ssl_storage_port on the public IP firewall.  (For intra-Region
+#    traffic, Scylla will switch to the private IP after
+#    establishing a connection.)
+#  - RackInferringSnitch:
+#    Proximity is determined by rack and data center, which are
+#    assumed to correspond to the 3rd and 2nd octet of each node's IP
+#    address, respectively.  Unless this happens to match your
+#    deployment conventions, this is best used as an example of
+#    writing a custom Snitch class and is provided in that spirit.
+#
+# You can use a custom Snitch by setting this to the full class name
+# of the snitch, which will be assumed to be on your classpath.
+endpoint_snitch: SimpleSnitch
+
+# The address or interface to bind the native transport server to.
+#
+# Set rpc_address OR rpc_interface, not both. Interfaces must correspond
+# to a single address, IP aliasing is not supported.
+#
+# Leaving rpc_address blank has the same effect as on listen_address
+# (i.e. it will be based on the configured hostname of the node).
+#
+# Note that unlike listen_address, you can specify 0.0.0.0, but you must also
+# set broadcast_rpc_address to a value other than 0.0.0.0.
+#
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+#
+# If you choose to specify the interface by name and the interface has an ipv4 and an ipv6 address
+# you can specify which should be chosen using rpc_interface_prefer_ipv6. If false the first ipv4
+# address will be used. If true the first ipv6 address will be used. Defaults to false preferring
+# ipv4. If there is only one address it will be selected regardless of ipv4/ipv6.
+rpc_address: localhost
+# rpc_interface: eth1
+# rpc_interface_prefer_ipv6: false
+
+# port for REST API server
+api_port: 10000
+
+# IP for the REST API server
+api_address: 127.0.0.1
+
+# Log WARN on any batch size exceeding this value. 128 kiB per batch by default.
+# Caution should be taken on increasing the size of this threshold as it can lead to node instability.
+batch_size_warn_threshold_in_kb: 128
+
+# Fail any multiple-partition batch exceeding this value. 1 MiB (8x warn threshold) by default.
+batch_size_fail_threshold_in_kb: 1024
+
+# Authentication backend, identifying users
+# Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthenticator,
+# PasswordAuthenticator}.
+#
+# - AllowAllAuthenticator performs no checks - set it to disable authentication.
+# - PasswordAuthenticator relies on username/password pairs to authenticate
+#   users. It keeps usernames and hashed passwords in system_auth.credentials table.
+#   Please increase system_auth keyspace replication factor if you use this authenticator.
+# - com.scylladb.auth.TransitionalAuthenticator requires username/password pair
+#   to authenticate in the same manner as PasswordAuthenticator, but improper credentials
+#   result in being logged in as an anonymous user. Use for upgrading clusters' auth.
+# authenticator: AllowAllAuthenticator
+
+# Authorization backend, implementing IAuthorizer; used to limit access/provide permissions
+# Out of the box, Scylla provides org.apache.cassandra.auth.{AllowAllAuthorizer,
+# CassandraAuthorizer}.
+#
+# - AllowAllAuthorizer allows any action to any user - set it to disable authorization.
+# - CassandraAuthorizer stores permissions in system_auth.permissions table. Please
+#   increase system_auth keyspace replication factor if you use this authorizer.
+# - com.scylladb.auth.TransitionalAuthorizer wraps around the CassandraAuthorizer, using it for
+#   authorizing permission management. Otherwise, it allows all. Use for upgrading
+#   clusters' auth.
+# authorizer: AllowAllAuthorizer
+
+# initial_token allows you to specify tokens manually.  While you can use # it with
+# vnodes (num_tokens > 1, above) -- in which case you should provide a 
+# comma-separated list -- it's primarily used when adding nodes # to legacy clusters 
+# that do not have vnodes enabled.
+# initial_token:
+
+# RPC address to broadcast to drivers and other Scylla nodes. This cannot
+# be set to 0.0.0.0. If left blank, this will be set to the value of
+# rpc_address. If rpc_address is set to 0.0.0.0, broadcast_rpc_address must
+# be set.
+# broadcast_rpc_address: 1.2.3.4
+
+# Uncomment to enable experimental features
+# experimental_features:
+#     - udf
+#     - alternator-streams
+#     - broadcast-tables
+#     - keyspace-storage-options
+
+# The directory where hints files are stored if hinted handoff is enabled.
+# hints_directory: /var/lib/scylla/hints
+ 
+# The directory where hints files are stored for materialized-view updates
+# view_hints_directory: /var/lib/scylla/view_hints
+
+# See https://docs.scylladb.com/architecture/anti-entropy/hinted-handoff
+# May either be "true" or "false" to enable globally, or contain a list
+# of data centers to enable per-datacenter.
+# hinted_handoff_enabled: DC1,DC2
+# hinted_handoff_enabled: true
+
+# this defines the maximum amount of time a dead host will have hints
+# generated.  After it has been dead this long, new hints for it will not be
+# created until it has been seen alive and gone down again.
+# max_hint_window_in_ms: 10800000 # 3 hours
+
+
+# Validity period for permissions cache (fetching permissions can be an
+# expensive operation depending on the authorizer, CassandraAuthorizer is
+# one example). Defaults to 10000, set to 0 to disable.
+# Will be disabled automatically for AllowAllAuthorizer.
+# permissions_validity_in_ms: 10000
+
+# Refresh interval for permissions cache (if enabled).
+# After this interval, cache entries become eligible for refresh. Upon next
+# access, an async reload is scheduled and the old value returned until it
+# completes. If permissions_validity_in_ms is non-zero, then this also must have
+# a non-zero value. Defaults to 2000. It's recommended to set this value to
+# be at least 3 times smaller than the permissions_validity_in_ms.
+# permissions_update_interval_in_ms: 2000
+
+# The partitioner is responsible for distributing groups of rows (by
+# partition key) across nodes in the cluster.  You should leave this
+# alone for new clusters.  The partitioner can NOT be changed without
+# reloading all data, so when upgrading you should set this to the
+# same partitioner you were already using.
+#
+# Murmur3Partitioner is currently the only supported partitioner,
+#
+partitioner: org.apache.cassandra.dht.Murmur3Partitioner
+
+# Total space to use for commitlogs.
+#
+# If space gets above this value (it will round up to the next nearest
+# segment multiple), Scylla will flush every dirty CF in the oldest
+# segment and remove it.  So a small total commitlog space will tend
+# to cause more flush activity on less-active columnfamilies.
+#
+# A value of -1 (default) will automatically equate it to the total amount of memory
+# available for Scylla.
+commitlog_total_space_in_mb: -1
+
+# TCP port, for commands and data
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# storage_port: 7000
+
+# SSL port, for encrypted communication.  Unused unless enabled in
+# encryption_options
+# For security reasons, you should not expose this port to the internet.  Firewall it if needed.
+# ssl_storage_port: 7001
+
+# listen_interface: eth0
+# listen_interface_prefer_ipv6: false
+
+# Whether to start the native transport server.
+# Please note that the address on which the native transport is bound is the
+# same as the rpc_address. The port however is different and specified below.
+# start_native_transport: true
+
+# The maximum size of allowed frame. Frame (requests) larger than this will
+# be rejected as invalid. The default is 256MB.
+# native_transport_max_frame_size_in_mb: 256
+
+# enable or disable keepalive on rpc/native connections
+# rpc_keepalive: true
+
+# Set to true to have Scylla create a hard link to each sstable
+# flushed or streamed locally in a backups/ subdirectory of the
+# keyspace data.  Removing these links is the operator's
+# responsibility.
+# incremental_backups: false
+
+# Whether or not to take a snapshot before each compaction.  Be
+# careful using this option, since Scylla won't clean up the
+# snapshots for you.  Mostly useful if you're paranoid when there
+# is a data format change.
+# snapshot_before_compaction: false
+
+# Whether or not a snapshot is taken of the data before keyspace truncation
+# or dropping of column families. The STRONGLY advised default of true 
+# should be used to provide data safety. If you set this flag to false, you will
+# lose data on truncation or drop.
+# auto_snapshot: true
+
+# When executing a scan, within or across a partition, we need to keep the
+# tombstones seen in memory so we can return them to the coordinator, which
+# will use them to make sure other replicas also know about the deleted rows.
+# With workloads that generate a lot of tombstones, this can cause performance
+# problems and even exhaust the server heap.
+# (http://www.datastax.com/dev/blog/cassandra-anti-patterns-queues-and-queue-like-datasets)
+# Adjust the thresholds here if you understand the dangers and want to
+# scan more tombstones anyway.  These thresholds may also be adjusted at runtime
+# using the StorageService mbean.
+# tombstone_warn_threshold: 1000
+# tombstone_failure_threshold: 100000
+
+# Granularity of the collation index of rows within a partition.
+# Increase if your rows are large, or if you have a very large
+# number of rows per partition.  The competing goals are these:
+#   1) a smaller granularity means more index entries are generated
+#      and looking up rows within the partition by collation column
+#      is faster
+#   2) but, Scylla will keep the collation index in memory for hot
+#      rows (as part of the key cache), so a larger granularity means
+#      you can cache more hot rows
+# column_index_size_in_kb: 64
+
+# Auto-scaling of the promoted index prevents running out of memory
+# when the promoted index grows too large (due to partitions with many rows
+# vs. too small column_index_size_in_kb).  When the serialized representation
+# of the promoted index grows by this threshold, the desired block size
+# for this partition (initialized to column_index_size_in_kb)
+# is doubled, to decrease the sampling resolution by half.
+#
+# To disable promoted index auto-scaling, set the threshold to 0.
+# column_index_auto_scale_threshold_in_kb: 10240
+
+# Log a warning when writing partitions larger than this value
+# compaction_large_partition_warning_threshold_mb: 1000
+
+# Log a warning when writing rows larger than this value
+# compaction_large_row_warning_threshold_mb: 10
+
+# Log a warning when writing cells larger than this value
+# compaction_large_cell_warning_threshold_mb: 1
+
+# Log a warning when row number is larger than this value
+# compaction_rows_count_warning_threshold: 100000
+
+# Log a warning when writing a collection containing more elements than this value
+# compaction_collection_elements_count_warning_threshold: 10000
+
+# How long the coordinator should wait for seq or index scans to complete
+# range_request_timeout_in_ms: 10000
+# How long the coordinator should wait for writes to complete
+# counter_write_request_timeout_in_ms: 5000
+# How long a coordinator should continue to retry a CAS operation
+# that contends with other proposals for the same row
+# cas_contention_timeout_in_ms: 1000
+# How long the coordinator should wait for truncates to complete
+# (This can be much longer, because unless auto_snapshot is disabled
+# we need to flush first so we can snapshot before removing the data.)
+# truncate_request_timeout_in_ms: 60000
+# The default timeout for other, miscellaneous operations
+# request_timeout_in_ms: 10000
+
+# Enable or disable inter-node encryption. 
+# You must also generate keys and provide the appropriate key and trust store locations and passwords. 
+#
+# The available internode options are : all, none, dc, rack
+# If set to dc scylla  will encrypt the traffic between the DCs
+# If set to rack scylla  will encrypt the traffic between the racks
+#
+# SSL/TLS algorithm and ciphers used can be controlled by 
+# the priority_string parameter. Info on priority string
+# syntax and values is available at:
+#   https://gnutls.org/manual/html_node/Priority-Strings.html
+#
+# The require_client_auth parameter allows you to 
+# restrict access to service based on certificate 
+# validation. Client must provide a certificate 
+# accepted by the used trust store to connect.
+# 
+# server_encryption_options:
+#    internode_encryption: none
+#    certificate: conf/scylla.crt
+#    keyfile: conf/scylla.key
+#    truststore: <not set, use system trust>
+#    certficate_revocation_list: <not set>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# enable or disable client/server encryption.
+# client_encryption_options:
+#    enabled: false
+#    certificate: conf/scylla.crt
+#    keyfile: conf/scylla.key
+#    truststore: <not set, use system trust>
+#    certficate_revocation_list: <not set>
+#    require_client_auth: False
+#    priority_string: <not set, use default>
+
+# internode_compression controls whether traffic between nodes is
+# compressed.
+# can be:  all  - all traffic is compressed
+#          dc   - traffic between different datacenters is compressed
+#          none - nothing is compressed.
+# internode_compression: none
+
+# Enable or disable tcp_nodelay for inter-dc communication.
+# Disabling it will result in larger (but fewer) network packets being sent,
+# reducing overhead from the TCP protocol itself, at the cost of increasing
+# latency if you block for cross-datacenter responses.
+# inter_dc_tcp_nodelay: false
+
+# Relaxation of environment checks.
+#
+# Scylla places certain requirements on its environment.  If these requirements are
+# not met, performance and reliability can be degraded.
+#
+# These requirements include:
+#    - A filesystem with good support for asynchronous I/O (AIO). Currently,
+#      this means XFS.
+#
+# false: strict environment checks are in place; do not start if they are not met.
+# true: relaxed environment checks; performance and reliability may degraade.
+#
+# developer_mode: false
+
+
+# Idle-time background processing
+#
+# Scylla can perform certain jobs in the background while the system is otherwise idle,
+# freeing processor resources when there is other work to be done.
+#
+# defragment_memory_on_idle: true
+#
+# prometheus port
+# By default, Scylla opens prometheus API port on port 9180
+# setting the port to 0 will disable the prometheus API.
+# prometheus_port: 9180
+#
+# prometheus address
+# Leaving this blank will set it to the same value as listen_address.
+# This means that by default, Scylla listens to the prometheus API on the same
+# listening address (and therefore network interface) used to listen for
+# internal communication. If the monitoring node is not in this internal
+# network, you can override prometheus_address explicitly - e.g., setting
+# it to 0.0.0.0 to listen on all interfaces.
+# prometheus_address: 1.2.3.4
+
+# Distribution of data among cores (shards) within a node
+#
+# Scylla distributes data within a node among shards, using a round-robin
+# strategy:
+#  [shard0] [shard1] ... [shardN-1] [shard0] [shard1] ... [shardN-1] ...
+#
+# Scylla versions 1.6 and below used just one repetition of the pattern;
+# this interfered with data placement among nodes (vnodes).
+#
+# Scylla versions 1.7 and above use 4096 repetitions of the pattern; this
+# provides for better data distribution.
+#
+# the value below is log (base 2) of the number of repetitions.
+#
+# Set to 0 to avoid rewriting all data when upgrading from Scylla 1.6 and
+# below.
+#
+# Keep at 12 for new clusters.
+murmur3_partitioner_ignore_msb_bits: 12
+
+# Use on a new, parallel algorithm for performing aggregate queries.
+# Set to `false` to fall-back to the old algorithm.
+# enable_parallelized_aggregation: true
+
+# Time for which task manager task is kept in memory after it completes.
+# task_ttl_in_seconds: 0
+
+# In materialized views, restrictions are allowed only on the view's primary key columns.
+# In old versions Scylla mistakenly allowed IS NOT NULL restrictions on columns which were not part
+# of the view's primary key. These invalid restrictions were ignored.
+# This option controls the behavior when someone tries to create a view with such invalid IS NOT NULL restrictions.
+#
+# Can be true, false, or warn.
+# * `true`: IS NOT NULL is allowed only on the view's primary key columns,
+#           trying to use it on other columns will cause an error, as it should.
+# * `false`: Scylla accepts IS NOT NULL restrictions on regular columns, but they're silently ignored.
+#            It's useful for backwards compatibility.
+# * `warn`: The same as false, but there's a warning about invalid view restrictions.
+#
+# To preserve backwards compatibility on old clusters, Scylla's default setting is `warn`.
+# New clusters have this option set to `true` by scylla.yaml (which overrides the default `warn`)
+# to make sure that trying to create an invalid view causes an error.
+strict_is_not_null_in_views: true
+
+# The Unix Domain Socket the node uses for maintenance socket.
+# The possible options are:
+# * ignore: the node will not open the maintenance socket,
+# * workdir: the node will open the maintenance socket on the path <scylla's workdir>/cql.m,
+#            where <scylla's workdir> is a path defined by the workdir configuration option,
+# * <socket path>: the node will open the maintenance socket on the path <socket path>.
+maintenance_socket: ignore
+
+# If set to true, configuration parameters defined with LiveUpdate option can be updated in runtime with CQL
+# by updating system.config virtual table. If we don't want any configuration parameter to be changed in runtime
+# via CQL, this option should be set to false. This parameter doesn't impose any limits on other mechanisms updating
+# configuration parameters in runtime, e.g. sending SIGHUP or using API. This option should be set to false
+# e.g. for cloud users, for whom scylla's configuration should be changed only by support engineers.
+# live_updatable_config_params_changeable_via_cql: true
+
+# ****************
+# *  GUARDRAILS  *
+# ****************
+
+# Guardrails to warn or fail when Replication Factor is smaller/greater than the threshold.
+# Please note that the value of 0 is always allowed,
+# which means that having no replication at all, i.e. RF = 0, is always valid.
+# A guardrail value smaller than 0, e.g. -1, means that the guardrail is disabled.
+# Commenting out a guardrail also means it is disabled.
+# minimum_replication_factor_fail_threshold: -1
+# minimum_replication_factor_warn_threshold:  3
+# maximum_replication_factor_warn_threshold: -1
+# maximum_replication_factor_fail_threshold: -1
+
+# Guardrails to warn about or disallow creating a keyspace with specific replication strategy.
+# Each of these 2 settings is a list storing replication strategies considered harmful.
+# The replication strategies to choose from are:
+# 1) SimpleStrategy,
+# 2) NetworkTopologyStrategy,
+# 3) LocalStrategy,
+# 4) EverywhereStrategy
+#
+# replication_strategy_warn_list:
+#  - SimpleStrategy
+# replication_strategy_fail_list:
+
+# Enables the tablets feature.
+# When enabled, newly created keyspaces will have tablets enabled by default.
+# That can be explicitly disabled in the CREATE KEYSPACE query
+# by using the `tablets = {'enabled': false}` replication option.
+#
+# When the tablets feature is disabled, there is no way to enable tablets
+# per keyspace.
+#
+# Note that creating keyspaces with tablets enabled is irreversible.
+# Disabling the tablets feature may impact existing keyspaces that were created with tablets.
+# For example, the tablets map would remain "frozen" and will not respond to topology changes
+# like adding, removing, or replacing nodes, or to replication factor changes.
+enable_tablets: true
+api_ui_dir: /opt/scylladb/swagger-ui/dist/
+api_doc_dir: /opt/scylladb/api/api-doc/
+
+alternator_encryption_options:
+  enable_session_tickets: true
+  certificate: /etc/scylla/db.crt
+  keyfile: /etc/scylla/db.key
+
+alternator_https_port: 9999
+alternator_port: 9998
+alternator_write_isolation: only_rmw_uses_lwt
+

--- a/python/pylintrc
+++ b/python/pylintrc
@@ -1,0 +1,503 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=pydantic ; https://github.com/pydantic/pydantic/issues/1961#issuecomment-759522422
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        missing-docstring,
+        fixme,
+        no-else-return,
+        logging-format-interpolation,
+        possibly-unused-variable,
+        cyclic-import,
+        duplicate-code,
+        logging-fstring-interpolation,
+        logging-not-lazy,
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package..
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+# TODO: remove all boto3 stuff until https://github.com/PyCQA/pylint/issues/3134 is fixed
+generated-members=.*dynamodb.*, .*boto3.*, .*ec2.*, .*s3.* , .*self.nodes.*, .*self.log.*, .*self.params.*, .*self._param_enabled.*
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=cassandra,xmlrunner,repodataParser
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=240
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+#argument-rgx=
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           s3,
+           ok,
+           ip,
+           dc,
+           ks,
+           cf,
+           fd,
+           pytestmark,
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+#variable-rgx=
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=6
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, while `new` is for `{}` formatting.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=20
+
+# Maximum number of boolean expressions in an if statement.
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=12
+
+# Maximum number of locals for function / method body.
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=6
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[EXCEPTIONS]
+

--- a/python/requirement-test.txt
+++ b/python/requirement-test.txt
@@ -1,0 +1,7 @@
+pylint>=3.3.6
+boto3>=1.37.33
+botocore>=1.37.33
+autopep8>=2.3.2
+pytest>=8.3.5
+ruff>=0.11.5
+requests>=2.32.3

--- a/python/test_integration_boto3.py
+++ b/python/test_integration_boto3.py
@@ -7,11 +7,13 @@ class TestAlternatorBotocore:
     https_port = 9999
 
     def test_check_if_rack_datacenter_feature_is_supported(self):
-        lb = AlternatorLB(Config(nodes=self.initial_nodes, port=self.http_port, datacenter="fake_dc"))
+        lb = AlternatorLB(Config(nodes=self.initial_nodes,
+                          port=self.http_port, datacenter="fake_dc"))
         lb.check_if_rack_datacenter_feature_is_supported()
 
     def test_check_if_rack_and_datacenter_set_correctly_wrong_dc(self):
-        lb = AlternatorLB(Config(nodes=self.initial_nodes, port=self.http_port, datacenter="fake_dc"))
+        lb = AlternatorLB(Config(nodes=self.initial_nodes,
+                          port=self.http_port, datacenter="fake_dc"))
         try:
             lb.check_if_rack_and_datacenter_set_correctly()
             assert False, "Expected ValueError"
@@ -19,11 +21,13 @@ class TestAlternatorBotocore:
             pass
 
     def test_check_if_rack_and_datacenter_set_correctly_correct_dc(self):
-        lb = AlternatorLB(Config(nodes=self.initial_nodes, port=self.http_port, datacenter="datacenter1"))
+        lb = AlternatorLB(Config(nodes=self.initial_nodes,
+                          port=self.http_port, datacenter="datacenter1"))
         lb.check_if_rack_and_datacenter_set_correctly()
 
     def _run_create_add_delete_test(self, dynamodb):
-        lb = AlternatorLB(Config(nodes=self.initial_nodes, port=self.http_port))
+        lb = AlternatorLB(
+            Config(nodes=self.initial_nodes, port=self.http_port))
         lb.patch_dynamodb_client(dynamodb)
 
         TABLE_NAME = "TestTable"
@@ -37,9 +41,12 @@ class TestAlternatorBotocore:
         print("Creating table...")
         dynamodb.create_table(
             TableName=TABLE_NAME,
-            KeySchema=[{'AttributeName': 'UserID', 'KeyType': 'HASH'}],  # Primary Key
-            AttributeDefinitions=[{'AttributeName': 'UserID', 'AttributeType': 'S'}],  # String Key
-            ProvisionedThroughput={'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
+            KeySchema=[{'AttributeName': 'UserID',
+                        'KeyType': 'HASH'}],  # Primary Key
+            AttributeDefinitions=[
+                {'AttributeName': 'UserID', 'AttributeType': 'S'}],  # String Key
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
         )
         print(f"Table '{TABLE_NAME}' creation started.")
 
@@ -71,10 +78,11 @@ class TestAlternatorBotocore:
         import botocore.session
 
         # Create a DynamoDB client
-        self._run_create_add_delete_test(botocore.session.get_session().create_client('dynamodb', region_name='us-east-1'))
+        self._run_create_add_delete_test(botocore.session.get_session(
+        ).create_client('dynamodb', region_name='us-east-1', aws_access_key_id="fake-key-id", aws_secret_access_key="fake-key"))
 
     def test_boto3_create_add_delete(self):
         import boto3
 
-        self._run_create_add_delete_test(boto3.client('dynamodb', region_name='us-east-1'))
-
+        self._run_create_add_delete_test(
+            boto3.client('dynamodb', region_name='us-east-1', aws_access_key_id="fake-key-id", aws_secret_access_key="fake-key"))

--- a/python/test_integration_boto3.py
+++ b/python/test_integration_boto3.py
@@ -1,28 +1,29 @@
-import unittest
+from alternator_lb import AlternatorLB, Config
 
-from alternator_lb import AlternatorLB
 
-class AlternatorBotocoreTests(unittest.TestCase):
-    initial_nodes = ['172.17.0.2']
+class TestAlternatorBotocore:
+    initial_nodes = ['172.43.0.2']
+    http_port = 9998
+    https_port = 9999
 
     def test_check_if_rack_datacenter_feature_is_supported(self):
-        lb = AlternatorLB(self.initial_nodes, 'http', 9999, datacenter="fake_dc")
+        lb = AlternatorLB(Config(nodes=self.initial_nodes, port=self.http_port, datacenter="fake_dc"))
         lb.check_if_rack_datacenter_feature_is_supported()
 
     def test_check_if_rack_and_datacenter_set_correctly_wrong_dc(self):
-        lb = AlternatorLB(self.initial_nodes, 'http', 9999, datacenter="fake_dc")
+        lb = AlternatorLB(Config(nodes=self.initial_nodes, port=self.http_port, datacenter="fake_dc"))
         try:
             lb.check_if_rack_and_datacenter_set_correctly()
-            self.fail("Expected ValueError")
+            assert False, "Expected ValueError"
         except ValueError:
             pass
 
     def test_check_if_rack_and_datacenter_set_correctly_correct_dc(self):
-        lb = AlternatorLB(self.initial_nodes, 'http', 9999, datacenter="datacenter1")
+        lb = AlternatorLB(Config(nodes=self.initial_nodes, port=self.http_port, datacenter="datacenter1"))
         lb.check_if_rack_and_datacenter_set_correctly()
 
     def _run_create_add_delete_test(self, dynamodb):
-        lb = AlternatorLB(self.initial_nodes, port=9999)
+        lb = AlternatorLB(Config(nodes=self.initial_nodes, port=self.http_port))
         lb.patch_dynamodb_client(dynamodb)
 
         TABLE_NAME = "TestTable"

--- a/python/test_unit.py
+++ b/python/test_unit.py
@@ -1,0 +1,64 @@
+import gc
+
+
+def test_executor_pool():
+    from alternator_lb import ExecutorPool
+
+    class FakePool:
+        def __init__(self, *args, **kwargs):
+            self.submit_counts = 0
+            self.shutdown_counts = 0
+
+        def submit(self, *args, **kwargs):
+            self.submit_counts += 1
+
+        def shutdown(self, *args, **kwargs):
+            pass
+
+
+    class ExecutorPoolPatch(ExecutorPool):
+        @classmethod
+        def create_executor(cls):
+            return FakePool()
+
+        def get_executor(self):
+            return self._executor
+
+    class SomeClass:
+        pool = ExecutorPoolPatch()
+
+        def __init__(self, *args, **kwargs):
+            self.pool.add_ref()
+
+        def __del__(self):
+            self.pool.remove_ref()
+
+        def submit(self, *args, **kwargs):
+            self.pool.submit(*args, **kwargs)
+
+    for _ in range(2):
+        e = SomeClass()
+        e1 = SomeClass()
+
+        e.pool.submit(None)
+        e1.pool.submit(None)
+
+        executor = e.pool.get_executor()
+        executor1 = e.pool.get_executor()
+        assert executor1 == executor
+        assert executor.submit_counts == 2
+
+        del e
+        del e1
+        del executor1
+        del executor
+        gc.collect()
+
+        assert SomeClass.pool.get_executor() is None
+
+
+
+
+
+
+

--- a/python/test_unit.py
+++ b/python/test_unit.py
@@ -15,7 +15,6 @@ def test_executor_pool():
         def shutdown(self, *args, **kwargs):
             pass
 
-
     class ExecutorPoolPatch(ExecutorPool):
         @classmethod
         def create_executor(cls):
@@ -55,10 +54,3 @@ def test_executor_pool():
         gc.collect()
 
         assert SomeClass.pool.get_executor() is None
-
-
-
-
-
-
-


### PR DESCRIPTION
Does the following:
1. Adds linters: `autopep8` and `ruff`
2. Adds docker-compose file for integration tests
3. Adds Makefile
4. Adds github workflow

Fixes: https://github.com/scylladb/alternator-load-balancing/issues/71