### PR TITLE
Add client certificate option

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -28,37 +28,21 @@ This library periodically syncs list of active nodes with the cluster.
 ### Create new dynamodb botocore client
 
 ```python
-import alternator_lb
+from alternator_lb import AlternatorLB, Config
 
-lb = alternator_lb.AlternatorLB(['x.x.x.x'], port=9999)
+lb = AlternatorLB(Config(nodes=['x.x.x.x'], port=9999))
 dynamodb = lb.new_botocore_dynamodb_client()
 
 dynamodb.delete_table(TableName="SomeTable")
 ```
 
-### Patch existing dynamodb botocore client
+### Create new dynamodb boto3 client
 
 ```python
-import alternator_lb
-import botocore.session
+from alternator_lb import AlternatorLB, Config
 
-lb = alternator_lb.AlternatorLB(['x.x.x.x'], port=9999)
-session = botocore.session.get_session()
-dynamodb = session.create_client('dynamodb', region_name='us-east-1')
-lb.patch_dynamodb_client(dynamodb)
-
-dynamodb.delete_table(TableName="SomeTable")
-```
-
-### Patch existing dynamodb boto3 client
-
-```python
-import alternator_lb
-import boto3
-
-lb = alternator_lb.AlternatorLB(['x.x.x.x'], port=9999)
-dynamodb = boto3.client('dynamodb', region_name='us-east-1')
-lb.patch_dynamodb_client(dynamodb)
+lb = AlternatorLB(Config(nodes=['x.x.x.x'], port=9999))
+dynamodb = lb.new_boto3_dynamodb_client()
 
 dynamodb.delete_table(TableName="SomeTable")
 ```

--- a/python/alternator_lb.py
+++ b/python/alternator_lb.py
@@ -273,7 +273,7 @@ class AlternatorLB:
             verify=False,
             config=self._init_botocore_config(),
         )
-        self.patch_dynamodb_client(ddb)
+        self._patch_dynamodb_client(ddb)
         return ddb
 
     def new_boto3_dynamodb_client(self, key: str = "", secret: str = "", region: str = ""):
@@ -294,10 +294,10 @@ class AlternatorLB:
             verify=False,
             config=self._init_botocore_config(),
         )
-        self.patch_dynamodb_client(ddb)
+        self._patch_dynamodb_client(ddb)
         return ddb
 
-    def patch_dynamodb_client(self, client):
+    def _patch_dynamodb_client(self, client):
         from botocore.regions import EndpointRulesetResolver
 
         current_resolver = getattr(client, '_ruleset_resolver', None)

--- a/python/alternator_lb.py
+++ b/python/alternator_lb.py
@@ -49,7 +49,10 @@ class Config:
     port: int = 8080
     datacenter: str = None
     rack: str = None
-    client_cert: str = None
+    client_cert_file: str = None
+    client_key_file: str = None
+    connect_timeout: int = 3600
+    max_pool_connections: int = 200
     aws_region_name: str = "fake-alternator-lb-region"
     aws_access_key_id: str = "fake-alternator-lb-access-key-id"
     aws_secret_access_key: str = "fake-alternator-lb-secret-access-key"
@@ -244,9 +247,14 @@ class AlternatorLB:
             "connect_timeout": self._config.connect_timeout,
             "max_pool_connections": self._config.max_pool_connections,
         }
+        if self._config.client_cert_file:
+            if self._config.client_key_file:
+                config_params["client_cert"] = (self._config.client_cert_file, self._config.client_key_file)
+            else:
+                config_params["client_cert"] = self._config.client_cert_file
         return config.Config(**config_params)
 
-    def new_botocore_dynamodb_client(self, key: str = "", secret: str = "", region: str = ""):
+    def new_botocore_dynamodb_client(self, key: str = "", secret: str = "", region: str = "") -> object:
         import botocore.session
 
         session = botocore.session.get_session()

--- a/python/test_integration_boto3.py
+++ b/python/test_integration_boto3.py
@@ -140,4 +140,5 @@ class TestAlternatorBotocore:
     def test_boto3_create_add_delete(self):
         lb = AlternatorLB(Config(nodes=self.initial_nodes,
                           port=self.http_port, datacenter="datacenter1"))
+        lb = AlternatorLB(Config(nodes=self.initial_nodes, port=self.http_port, datacenter="datacenter1"))
         self._run_create_add_delete_test(lb.new_boto3_dynamodb_client())


### PR DESCRIPTION
Add option to provide certificate and key file name.
Discontinue `patch_dynamodb_client` for public use.

Fixes: https://github.com/scylladb/alternator-load-balancing/issues/120